### PR TITLE
Dropped minimum version of vscode engine to 1.91.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
-        "@types/vscode": "^1.98.0",
+        "@types/vscode": "^1.91.0",
         "@typescript-eslint/eslint-plugin": "^8.25.0",
         "@typescript-eslint/parser": "^8.25.0",
         "@vscode/test-cli": "^0.0.10",
@@ -21,7 +21,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "vscode": "^1.98.0"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/th7as/text-compare.git"
     },
     "engines": {
-        "vscode": "^1.98.0"
+        "vscode": "^1.91.0"
     },
     "categories": [
         "Other"
@@ -196,7 +196,7 @@
         "test": "vscode-test"
     },
     "devDependencies": {
-        "@types/vscode": "^1.98.0",
+        "@types/vscode": "^1.91.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
         "@typescript-eslint/eslint-plugin": "^8.25.0",


### PR DESCRIPTION
At work, we're locked into vscode version 1.91.0 for now and I wasn't able to use this super useful extension until I updated and rebuilt with the package.json engine section with vscode set to be at least 1.91.0. I've been using it this way for about a month and it's been working great! I want to be able to have other team members pull it down from the official repo.

Thanks for making this! It's incredibly useful for preventing or deduplicating duplicated code!